### PR TITLE
Reversing match order

### DIFF
--- a/bplax.py
+++ b/bplax.py
@@ -113,7 +113,7 @@ class MainPage(webapp2.RequestHandler):
         # Match that had just been written would not show up in a
         # query.
         match_query = Match.query(
-            ancestor=season_key(season_name)).order(-Match.date)
+            ancestor=season_key(season_name)).order(Match.date)
         matches = match_query.fetch(100)
 
         for match in matches:


### PR DESCRIPTION
Reversing order of matches so that they show up in chronological order and BPA over time calculation is fixed.